### PR TITLE
ringbuf: fix up wrong store/load operate functions in ringbuf.h

### DIFF
--- a/inc/fast/ringbuf.h
+++ b/inc/fast/ringbuf.h
@@ -237,7 +237,7 @@ static inline void
 __store_ring(struct rte_ring *r, uint_fast32_t head, void * const* obj, unsigned n)
 {
     unsigned i;
-    unsigned loops = n & 0x3;
+    unsigned loops = n & (~(unsigned) 0x03U);
     unsigned idx   = head & r->mask;
 
 
@@ -284,7 +284,7 @@ static inline void
 __load_ring(struct rte_ring *r, uint_fast32_t head, void **obj, unsigned n)
 {
     unsigned i;
-    unsigned loops = n & 0x3;
+    unsigned loops = n & (~(unsigned) 0x03U);
     unsigned idx   = head & r->mask;
 
 


### PR DESCRIPTION
Fix up wrong loop counter in function __store_ring() and __load_ring()
in file "fast/ringbuf.h".

Fixes bug report #1 